### PR TITLE
To-do app feature requests

### DIFF
--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -67,8 +67,8 @@ header {
   li {
     float: left;
     display: inline;
-    width: 145px;
-    text-align: center;
+    min-width: 145px;
+    padding-left: 18px;
     height: 25%;
     a {
       text-decoration: none;

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -1,5 +1,8 @@
 class Project < ActiveRecord::Base
+  default_scope { where(deleted: false) }
+
   validates :title, presence: true
   validates :title, uniqueness: true
+  validates :deleted, inclusion: { in: [ true, false ] }
   has_many :items, dependent: :destroy
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -1,4 +1,5 @@
 class Project < ActiveRecord::Base
   validates :title, presence: true
+  validates :title, uniqueness: true
   has_many :items, dependent: :destroy
 end

--- a/app/views/items/_index.html.erb
+++ b/app/views/items/_index.html.erb
@@ -16,4 +16,4 @@
 <% end %>
 </ul>
 
-<%= link_to 'New Item', new_project_path(project) %>
+<%= link_to 'New Item', new_project_item_path(project) %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,7 +13,7 @@
       <h1>Todo app</h1>
       <nav>
         <ul>
-          <li><%= link_to 'Projects', projects_path %></li>
+          <li><%= link_to 'Projects', projects_path %><% if @project %>&nbsp;/&nbsp;<%= @project.title %><% end %></li>
         </ul>
       </nav>
     </header>

--- a/db/migrate/20200624211353_add_index_to_project.rb
+++ b/db/migrate/20200624211353_add_index_to_project.rb
@@ -1,0 +1,5 @@
+class AddIndexToProject < ActiveRecord::Migration[6.0]
+  def change
+    add_index :projects, :title, unique: true
+  end
+end

--- a/db/migrate/20200624212531_add_deleted_to_project.rb
+++ b/db/migrate/20200624212531_add_deleted_to_project.rb
@@ -1,0 +1,5 @@
+class AddDeletedToProject < ActiveRecord::Migration[6.0]
+  def change
+    add_column :projects, :deleted, :boolean, null: false, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_24_211353) do
+ActiveRecord::Schema.define(version: 2020_06_24_212531) do
 
   create_table "items", force: :cascade do |t|
     t.string "action"
@@ -25,6 +25,7 @@ ActiveRecord::Schema.define(version: 2020_06_24_211353) do
     t.string "title"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.boolean "deleted", default: false, null: false
     t.index ["title"], name: "index_projects_on_title", unique: true
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_23_193942) do
+ActiveRecord::Schema.define(version: 2020_06_24_211353) do
 
   create_table "items", force: :cascade do |t|
     t.string "action"
@@ -25,6 +25,7 @@ ActiveRecord::Schema.define(version: 2020_06_23_193942) do
     t.string "title"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.index ["title"], name: "index_projects_on_title", unique: true
   end
 
 end

--- a/lib/tasks/output_project_todos.rake
+++ b/lib/tasks/output_project_todos.rake
@@ -1,0 +1,14 @@
+desc 'Output projects with corresponding items and completion state'
+
+task output_project_todos: :environment do
+  Project.includes(:items).each do |project|
+    puts project.title
+
+    project.items.each do |item|
+      completion_status = item.done ? 'X' : ' '
+      puts "- [#{completion_status}] #{item.action}"
+    end
+
+    puts "\n"
+  end
+end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -30,5 +30,9 @@ RSpec.describe Project do
       expect(project).to_not be_valid
       expect(project.errors.keys).to eq [:title]
     end
+
+    it "has a default deletion state" do
+      expect(subject.deleted).to be_falsey
+    end
   end
 end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -20,5 +20,15 @@ RSpec.describe Project do
       expect(subject).to_not be_valid
       expect(subject.errors.keys).to eq [:title]
     end
+
+    it "requires a unique title" do
+      duplicate_title = 'My Chores'
+
+      Project.create(title: duplicate_title)
+      project = Project.new(title: duplicate_title)
+
+      expect(project).to_not be_valid
+      expect(project.errors.keys).to eq [:title]
+    end
   end
 end

--- a/spec/system/creating_an_item_spec.rb
+++ b/spec/system/creating_an_item_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+RSpec.describe 'Creating an item', type: :system do
+  let(:project) { Project.create! title: 'My Project' }
+  let(:item) { Item.new action: 'Complete Modo Labs assignment' }
+  scenario 'Creating a valid item' do
+    visit project_path(project.id)
+
+    click_link 'New Item'
+    fill_in "Action", with: item.action
+    click_button "Create Item"
+
+    expect(page).to have_content(item.action)
+  end
+end

--- a/spec/system/viewing_soft_deleted_projects_spec.rb
+++ b/spec/system/viewing_soft_deleted_projects_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+RSpec.describe 'Viewing soft-deleted projects', type: :system do
+  scenario 'Soft-deleted projects are hidden from view' do
+    project = Project.create! title: 'My Project'
+    deleted_project = Project.create! title: 'Deleted Project', deleted: true
+
+    visit projects_path
+
+    expect(page).to have_content(project.title)
+    expect(page).to_not have_content(deleted_project.title)
+  end
+end


### PR DESCRIPTION
## Additions
- Adds a rake task to output projects and corresponding to-do informtion:
```ruby
rake output_project_todos
```

## Changes
- Allows "soft" deletion of projects
- Adds additional navigation information to UI

## Fixes
- Fixes creating to-do items in UI
- Ensures project titles are unique